### PR TITLE
Fix start line index when calling nvim_buf_get_lines

### DIFF
--- a/lua/carbon-now.lua
+++ b/lua/carbon-now.lua
@@ -88,7 +88,7 @@ local function get_open_command()
 end
 
 local function create_snippet(opts)
-  local lines = vim.api.nvim_buf_get_lines(0, opts.line1, opts.line2, false)
+  local lines = vim.api.nvim_buf_get_lines(0, opts.line1 - 1, opts.line2, false)
   lines = table.concat(lines, "\n", 1, #lines)
 
   local open_cmd = get_open_command()


### PR DESCRIPTION
Hi @ellisonleao,

Thanks for creating this plugin, it's been quite useful for me!
I noticed a minor issue with the way the visual selection works right now:
  - When calling `:CarbonNow` with visual selection, I noticed that the first line in my selection would get chopped off in the final carbon.sh snippet
  - I think this is because nvim_buf_get_lines() follows zero-based indexing, so we'll need to pass `opts.line1 - 1` as the start index to nvim_buf_get_lines in create_snippet

 Do let me know if this is a quirk particular to my setup and I'll be happy to recheck it.